### PR TITLE
bugfix/FUNFUNZ-118-useEntry-infinite-loop

### DIFF
--- a/src/hooks/useEntities.ts
+++ b/src/hooks/useEntities.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react"
+import { useSelector } from "reducers"
+import { listEntities } from "services/entities"
+import { IEntity } from "services/table"
+
+/*
+ * To be used on sidebar to render entity list
+ */
+export function useEntities(): IEntity[] {
+  const entities = useSelector((state) => state.tables)
+  const loading = useSelector((state) => state.loadingTables)
+  const error = useSelector((state) => state.error)
+  
+  useEffect(() => {
+    if ((!entities || entities.length === 0) && !loading && !error) {
+      listEntities()
+    } 
+  }, [loading, error, entities])
+
+  return entities
+}

--- a/src/hooks/useEntity.ts
+++ b/src/hooks/useEntity.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react"
+import { useSelector } from "reducers"
+import { IEntity } from "services/table"
+import { getEntity } from 'services/entity'
+import { IField, mapFieldComponents } from "utils/fields"
+
+/*
+ * To be used on Create, View and Edit page to render input fields
+ */
+export function useEntity(entityName: string): IEntity & { label: string, fields: IField[] } {
+  const entity = useSelector((state) => state.tables.find(t => t.name === entityName))
+  const loading = useSelector((state) => state.loadingTables || state.tables.find(t => t.name === entityName)?.loading)
+  const error = useSelector((state) => state.error)
+  
+  useEffect(() => { 
+    if ((entity?.name !== entityName || !entity?.properties?.length) && !loading && !error) {
+      getEntity(entityName)
+    } 
+  }, [entityName, loading, error, entity])
+
+  return entity
+    ? { 
+      ...entity,
+      fields: mapFieldComponents(entity),
+      label: entity.layout.label || entityName
+    }
+    : { 
+      name: entityName,
+      layout: { label: entityName },
+      label: entityName, 
+      properties: [],
+      fields: []
+    }
+}

--- a/src/hooks/useEntry.ts
+++ b/src/hooks/useEntry.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from "react"
+import { useSelector } from "reducers"
+import { IEntity } from "services/entity"
+import { entryDiff, entryEquals, getEntryData, IEntryData, IFilter, saveEntryData } from "services/entry"
+
+
+export interface IUseEntry {
+  entry: IEntryData,
+  setEntry: React.Dispatch<React.SetStateAction<IEntryData>>,
+  saveEntry: () => void,
+  error: boolean
+}
+
+/*
+ * To be used on Create, View and Edit pages to get and set entry values
+ */
+export function useEntry(entity: IEntity, filter?: IFilter): IUseEntry {
+  const fetchedEntry = useSelector((state) => state.entry) as IEntryData
+  const loading = useSelector((state) => state.loadingEntry)
+  const [error, setError] = useState(false)
+  const [entry, setEntry] = useState(fetchedEntry || {})
+  
+  useEffect(() => {
+    if (filter && !entryEquals(fetchedEntry, filter) && !loading && !error && entity.properties?.length) {
+      getEntryData(
+        entity.name,
+        filter,
+        entity.properties?.filter(p => p.layout?.visible?.entityPage).map(p => p.name)
+      ).then(
+        (data) => {
+          if (data && entryEquals(data, filter)) {
+            setEntry(data)
+          } else {
+            setError(true)
+          }
+        }
+      ).catch(
+        () => {
+          setError(true)
+        }
+      )
+    } 
+  }, [entity, filter, loading, error, fetchedEntry])
+
+  const saveEntry = useCallback(() => {
+    return saveEntryData(entity.name, entryDiff(fetchedEntry, entry), filter)
+  }, [entity, filter, entry, fetchedEntry])
+
+  return {
+    entry, 
+    setEntry, 
+    saveEntry,
+    error,
+  }
+}

--- a/src/services/entities.ts
+++ b/src/services/entities.ts
@@ -1,11 +1,9 @@
-import { useEffect } from "react"
-import { dispatch, useSelector } from "reducers"
+import { dispatch } from "reducers"
 import { 
   FETCH_ENTITIES_FULFILLED,
   FETCH_ENTITIES_PENDING,
   FETCH_ENTITIES_REJECTED
 } from "reducers/entity"
-import { IEntity } from "./entity"
 import graphql from "./graphql"
 
 export function listEntities() {
@@ -29,21 +27,4 @@ export function listEntities() {
       throw error
     }
   )
-}
-
-/*
- * To be used on sidebar to render entity list
- */
-export function useEntities(): IEntity[] {
-  const entities = useSelector((state) => state.tables)
-  const loading = useSelector((state) => state.loadingTables)
-  const error = useSelector((state) => state.error)
-  
-  useEffect(() => {
-    if ((!entities || entities.length === 0) && !loading && !error) {
-      listEntities()
-    } 
-  }, [loading, error, entities])
-
-  return entities
 }

--- a/src/services/entity.ts
+++ b/src/services/entity.ts
@@ -1,8 +1,6 @@
-import { useEffect } from "react"
-import { dispatch, useSelector } from "reducers"
+import { dispatch } from "reducers"
 import { FETCH_ENTITY_FULFILLED, FETCH_ENTITY_PENDING, FETCH_ENTITY_REJECTED } from "reducers/entity"
 import graphql from 'services/graphql'
-import { IField, mapFieldComponents } from "utils/fields"
 
 export interface IProperty {
   name: string,
@@ -79,33 +77,4 @@ export async function getEntity(entityName: string): Promise<IEntity> {
       throw error
     }
   )
-}
-
-/*
- * To be used on Create, View and Edit page to render input fields
- */
-export function useEntity(entityName: string): IEntity & { label: string, fields: IField[] } {
-  const entity = useSelector((state) => state.tables.find(t => t.name === entityName))
-  const loading = useSelector((state) => state.loadingTables || state.tables.find(t => t.name === entityName)?.loading)
-  const error = useSelector((state) => state.error)
-  
-  useEffect(() => { 
-    if ((entity?.name !== entityName || !entity?.properties?.length) && !loading && !error) {
-      getEntity(entityName)
-    } 
-  }, [entityName, loading, error, entity])
-
-  return entity
-    ? { 
-      ...entity,
-      fields: mapFieldComponents(entity),
-      label: entity.layout.label || entityName
-    }
-    : { 
-      name: entityName,
-      layout: { label: entityName },
-      label: entityName, 
-      properties: [],
-      fields: []
-    }
 }

--- a/src/services/entry.ts
+++ b/src/services/entry.ts
@@ -1,8 +1,6 @@
-import { useCallback, useEffect, useState } from "react"
-import { dispatch, useSelector } from "reducers"
+import { dispatch } from "reducers"
 import { FETCH_ENTRY_FULFILLED, FETCH_ENTRY_PENDING, FETCH_ENTRY_REJECTED } from "reducers/entry"
 import graphql, { IGQuery } from "./graphql"
-import { IEntity } from "./table"
 
 export interface IFilter {
   [key: string]: string | number | boolean
@@ -112,34 +110,4 @@ export function entryDiff(entry: any, newEntry: any) {
     }
   )
   return result
-}
-
-/*
- * To be used on Create, View and Edit pages to get and set entry values
- */
-export function useEntry(entity: IEntity, filter?: IFilter): [IEntryData, React.Dispatch<React.SetStateAction<IEntryData>>, () => Promise<void>] {
-  const entry = useSelector((state) => state.entry) as IEntryData
-  const loading = useSelector((state) => state.loadingEntry)
-  const error = useSelector((state) => state.errorEntry)
-  const [modifiedEntry, setEntry] = useState(entry || {})
-  
-  useEffect(() => {
-    if (filter && !entryEquals(entry, filter) && !loading && !error && entity.properties?.length) {
-      getEntryData(
-        entity.name,
-        filter,
-        entity.properties?.filter(p => p.layout?.visible?.entityPage).map(p => p.name)
-      ).then(
-        (data) => {
-          setEntry(data)
-        }
-      )
-    } 
-  }, [entity, filter, loading, error, entry])
-
-  const saveEntry = useCallback(() => {
-    return saveEntryData(entity.name, entryDiff(entry, modifiedEntry), filter)
-  }, [entity, filter, modifiedEntry, entry])
-
-  return [modifiedEntry, setEntry, saveEntry]
 }

--- a/src/views/playground/index.tsx
+++ b/src/views/playground/index.tsx
@@ -1,13 +1,13 @@
 import React, { FC, memo } from 'react'
-import { useEntities } from 'services/entities'
-import { useEntity } from 'services/entity'
-import { useEntry } from 'services/entry'
+import { useEntities } from 'hooks/useEntities'
+import { useEntity } from 'hooks/useEntity'
+import { useEntry } from 'hooks/useEntry'
 
 const Playground: FC = () => {
   const entities = useEntities()
   const entity = useEntity('products')
-  const [entry, setEntry, saveEntry] = useEntry(entity, { id: 1 })
-  const [newEntry, setNewEntry, addEntry] = useEntry(entity)
+  const { entry, setEntry, saveEntry } = useEntry(entity, { id: 1 })
+  const { entry: newEntry, setEntry: setNewEntry, saveEntry: addEntry } = useEntry(entity)
 
   return (
     <div>


### PR DESCRIPTION
* fix infinite loop on `useEntry`
* moved all hooks from service to hooks folder
* updated playground to use new hooks

### Notes:
* Heroku is down: I haven't tested this yet.
* I've changed the `useEntry` return type from an array to an object
* Possible conflicts with `feature/FUNFUNZ-100-new-and-edit-entry-page`branch because hooks have been moved